### PR TITLE
chore(gitignore): Ignore JetBrains .idea directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# IDE Directories
+.idea/


### PR DESCRIPTION
Adds the JetBrains `.idea/` directory to the ignore list to prevent user-specific editor settings from being committed to the repository. This keeps the project history clean and avoids potential conflicts between different development environments.